### PR TITLE
Add warmup feature

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ Rails:
 Naming/UncommunicativeMethodParamName:
   Enabled: false
 
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Enabled: false
 
 Style/TrivialAccessors:
@@ -40,7 +40,7 @@ Style/RegexpLiteral:
 Style/Lambda:
   Enabled: false
 
-Style/SpaceInsideStringInterpolation:
+Layout/SpaceInsideStringInterpolation:
   EnforcedStyle: no_space
 
 Style/ClassAndModuleChildren:

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ end
 
 ### With caching
 
-If you use caching, you can face the problem when first request performs more DB queries than others. The solution is:
+If you use caching you can face the problem when first request performs more DB queries than others. The solution is:
 
 ```ruby
 # RSpec

--- a/README.md
+++ b/README.md
@@ -147,6 +147,56 @@ def test_no_n_plus_one_error
 end
 ```
 
+### With caching
+
+If you use caching, you can face the problem when first request performs more DB queries than others. The solution is:
+
+```ruby
+# RSpec
+
+context "N + 1", :n_plus_one do
+  populate { |n| create_list :post, n }
+  
+  warmup { get :index } # cache something must be cached
+  
+  specify do
+    expect { get :index }.to perform_constant_number_of_queries
+  end
+end
+
+# Minitest
+
+def populate(n)
+  create_list(:post, n)
+end
+
+def warmup
+  get :index
+end
+
+def test_no_n_plus_one_error
+  assert_perform_constant_number_of_queries do
+    get :index
+  end
+end
+
+# or with params
+
+def test_no_n_plus_one
+  populate = ->(n) { create_list(:post, n) }
+  warmup = -> { get :index }
+  
+  assert_perform_constant_number_of_queries population: populate, warmup: warmup do
+    get :index
+  end
+end
+```
+
+If your `warmup` and testing procs are identical, you can use:
+```ruby
+expext { get :index }.to perform_constant_number_of_queries.with_warming_up # RSpec only
+```
+
 ### Configuration
 
 There are some global configuration parameters (and their corresponding defaults):

--- a/lib/n_plus_one_control/minitest.rb
+++ b/lib/n_plus_one_control/minitest.rb
@@ -5,13 +5,20 @@ require "n_plus_one_control"
 module NPlusOneControl
   # Minitest assertions
   module MinitestHelper
+    def warming_up(warmup)
+      (warmup || methods.include?(:warmup) ? method(:warmup) : nil)&.call
+    end
+
     def assert_perform_constant_number_of_queries(
       populate: nil,
       matching: nil,
-      scale_factors: nil
+      scale_factors: nil,
+      warmup: nil
     )
 
       raise ArgumentError, "Block is required" unless block_given?
+
+      warming_up warmup
 
       queries = NPlusOneControl::Executor.call(
         population: populate || method(:populate),

--- a/lib/n_plus_one_control/rspec/context.rb
+++ b/lib/n_plus_one_control/rspec/context.rb
@@ -17,5 +17,8 @@
     ->(n) { ex.instance_exec(n, &ex.example_group.populate) }
   end
 
-  let(:n_plus_one_warmup) { |ex| -> { ex.instance_exec &ex.example_group.warmup } }
+  let(:n_plus_one_warmup) do |ex|
+    return if ex.example_group.warmup.nil?
+    -> { ex.instance_exec(&ex.example_group.warmup) }
+  end
 end

--- a/lib/n_plus_one_control/rspec/context.rb
+++ b/lib/n_plus_one_control/rspec/context.rb
@@ -16,4 +16,6 @@
     end
     ->(n) { ex.instance_exec(n, &ex.example_group.populate) }
   end
+
+  let(:n_plus_one_warmup) { |ex| -> { ex.instance_exec &ex.example_group.warmup } }
 end

--- a/lib/n_plus_one_control/rspec/dsl.rb
+++ b/lib/n_plus_one_control/rspec/dsl.rb
@@ -2,7 +2,7 @@
 
 module NPlusOneControl
   module RSpec
-    # Extends RSpec ExampleGroup with populate method
+    # Extends RSpec ExampleGroup with populate & warmup methods
     module DSL
       # Setup warmup block, wich will run before matching
       # for example, if using cache, then later queries

--- a/lib/n_plus_one_control/rspec/dsl.rb
+++ b/lib/n_plus_one_control/rspec/dsl.rb
@@ -4,6 +4,15 @@ module NPlusOneControl
   module RSpec
     # Extends RSpec ExampleGroup with populate method
     module DSL
+      # Setup warmup block, wich will run before matching
+      # for example, if using cache, then later queries
+      # will perform less DB queries than first
+      def warmup
+        return @warmup unless block_given?
+
+        @warmup = Proc.new
+      end
+
       # Setup populate callback, which is used
       # to prepare data for each run.
       def populate

--- a/lib/n_plus_one_control/rspec/matcher.rb
+++ b/lib/n_plus_one_control/rspec/matcher.rb
@@ -19,6 +19,9 @@
       @matcher_execution_context.respond_to?(:n_plus_one_populate)
 
     populate = @matcher_execution_context.n_plus_one_populate
+    warmup = @matcher_execution_context.n_plus_one_warmup
+
+    warmup.call if warmup.present?
 
     # by default we're looking for select queries
     pattern = @pattern || /^SELECT/i

--- a/lib/n_plus_one_control/rspec/matcher.rb
+++ b/lib/n_plus_one_control/rspec/matcher.rb
@@ -12,6 +12,10 @@
     @pattern = pattern
   end
 
+  chain :with_warming_up do
+    @warmup = true
+  end
+
   match do |actual, *_args|
     raise ArgumentError, "Block is required" unless actual.is_a? Proc
 
@@ -19,7 +23,7 @@
       @matcher_execution_context.respond_to?(:n_plus_one_populate)
 
     populate = @matcher_execution_context.n_plus_one_populate
-    warmup = @matcher_execution_context.n_plus_one_warmup
+    warmup = @warmup ? actual : @matcher_execution_context.n_plus_one_warmup
 
     warmup.call if warmup.present?
 

--- a/spec/n_plus_one_control/rspec_spec.rb
+++ b/spec/n_plus_one_control/rspec_spec.rb
@@ -81,4 +81,24 @@ describe NPlusOneControl::RSpec do
         .to perform_constant_number_of_queries.matching(/posts/)
     end
   end
+
+  context 'with warming up', :n_plus_one do
+    let(:cache) { double "cache" }
+
+    before do
+      allow(cache).to receive(:setup).and_return(:result)
+      allow(NPlusOneControl::Executor).to receive(:call) { fail StandardError }
+    end
+
+    populate { |n| create_list(:post, n) }
+
+    warmup { cache.setup }
+
+    it "runs warmup before calling Executor" do
+      expect(cache).to receive(:setup)
+      expect do
+        expect { Post.find_each(&:id) }.to perform_constant_number_of_queries
+      end.to raise_error StandardError
+    end
+  end
 end

--- a/spec/n_plus_one_control/rspec_spec.rb
+++ b/spec/n_plus_one_control/rspec_spec.rb
@@ -87,7 +87,7 @@ describe NPlusOneControl::RSpec do
 
     before do
       allow(cache).to receive(:setup).and_return(:result)
-      allow(NPlusOneControl::Executor).to receive(:call) { fail StandardError }
+      allow(NPlusOneControl::Executor).to receive(:call) { raise StandardError }
     end
 
     populate { |n| create_list(:post, n) }
@@ -99,6 +99,15 @@ describe NPlusOneControl::RSpec do
       expect do
         expect { Post.find_each(&:id) }.to perform_constant_number_of_queries
       end.to raise_error StandardError
+    end
+  end
+
+  context 'with_warming_up', :n_plus_one do
+    populate { |n| create_list(:post, n) }
+
+    it "runs actual one more time" do
+      expect(Post).to receive(:all).exactly(3).times
+      expect { Post.all }.to perform_constant_number_of_queries.with_warming_up
     end
   end
 end


### PR DESCRIPTION
If you use caching in your models (e.g. IdentityCache), you can face with this:

```
       Expected to make the same number of queries, but got:
         21 for N=2
         13 for N=3
         13 for N=4
```

It is not N+1 but spec failed.

So I've added `warmup` method to DSL that called before we start measure queries.