### PR TITLE
Make current scale factor available in test

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,26 @@ expect { ... }.to perform_constant_number_of_queries.matching(/INSERT/)
 expect { ... }.to perform_constant_number_of_queries.with_scale_factors(10, 100)
 ```
 
+#### Using scale factor in spec
+
+Let's suppose your action accepts parameter, which can make impact on the number of returned records:
+
+```ruby
+get :index, params: { per_page: 10 }
+```
+
+Then it is enough to just change `per_page` parameter between executions and do not recreate records in DB. For this purpose, you can use `scale` method in your example:
+
+```ruby
+context "N+1", :n_plus_one do
+  before { create_list :post, 3 }
+
+  specify do
+    expect { get :index, params: { per_page: scale } }.to perform_constant_number_of_queries
+  end
+end
+```
+
 ### Minitest
 
 First, add NPlusOneControl to your `test_helper.rb`:
@@ -143,6 +163,16 @@ end
 def test_no_n_plus_one_error
   assert_perform_constant_number_of_queries do
     get :index
+  end
+end
+```
+
+As in RSpec, you can use `scale` factor instead of `populate` block:
+
+```ruby
+def test_no_n_plus_one_error
+  assert_perform_constant_number_of_queries do
+    get :index, params: { per_page: scale }
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ Let's suppose your action accepts parameter, which can make impact on the number
 get :index, params: { per_page: 10 }
 ```
 
-Then it is enough to just change `per_page` parameter between executions and do not recreate records in DB. For this purpose, you can use `scale` method in your example:
+Then it is enough to just change `per_page` parameter between executions and do not recreate records in DB. For this purpose, you can use `current_scale` method in your example:
 
 ```ruby
 context "N+1", :n_plus_one do
   before { create_list :post, 3 }
 
   specify do
-    expect { get :index, params: { per_page: scale } }.to perform_constant_number_of_queries
+    expect { get :index, params: { per_page: current_scale } }.to perform_constant_number_of_queries
   end
 end
 ```
@@ -167,12 +167,12 @@ def test_no_n_plus_one_error
 end
 ```
 
-As in RSpec, you can use `scale` factor instead of `populate` block:
+As in RSpec, you can use `current_scale` factor instead of `populate` block:
 
 ```ruby
 def test_no_n_plus_one_error
   assert_perform_constant_number_of_queries do
-    get :index, params: { per_page: scale }
+    get :index, params: { per_page: current_scale }
   end
 end
 ```

--- a/lib/n_plus_one_control/executor.rb
+++ b/lib/n_plus_one_control/executor.rb
@@ -42,9 +42,12 @@ module NPlusOneControl
     end
 
     def initialize(population: nil, scale_factors: nil, matching: nil)
-      @population, @scale_factors, @matching = population, scale_factors, matching
+      @population = population
+      @scale_factors = scale_factors
+      @matching = matching
     end
 
+    # rubocop:disable Metrics/MethodLength
     def call
       raise ArgumentError, "Block is required!" unless block_given?
 
@@ -60,6 +63,7 @@ module NPlusOneControl
       end
       results
     end
+    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/lib/n_plus_one_control/executor.rb
+++ b/lib/n_plus_one_control/executor.rb
@@ -31,7 +31,7 @@ module NPlusOneControl
       attr_accessor :transaction_rollback
     end
 
-    attr_reader :scale
+    attr_reader :current_scale
 
     self.transaction_begin = -> do
       ActiveRecord::Base.connection.begin_transaction(joinable: false)
@@ -55,7 +55,7 @@ module NPlusOneControl
       collector = Collector.new(matching)
 
       (scale_factors || NPlusOneControl.default_scale_factors).each do |scale|
-        @scale = scale
+        @current_scale = scale
         with_transaction do
           population&.call(scale)
           results << [scale, collector.call { yield }]

--- a/lib/n_plus_one_control/minitest.rb
+++ b/lib/n_plus_one_control/minitest.rb
@@ -29,8 +29,8 @@ module NPlusOneControl
       assert counts.max == counts.min, NPlusOneControl.failure_message(queries)
     end
 
-    def scale
-      @executor&.scale
+    def current_scale
+      @executor&.current_scale
     end
 
     private

--- a/lib/n_plus_one_control/rspec.rb
+++ b/lib/n_plus_one_control/rspec.rb
@@ -13,5 +13,6 @@ module NPlusOneControl
 end
 
 ::RSpec.configure do |config|
-  config.extend NPlusOneControl::RSpec::DSL, n_plus_one: true
+  config.extend NPlusOneControl::RSpec::DSL::ClassMethods, n_plus_one: true
+  config.include NPlusOneControl::RSpec::DSL, n_plus_one: true
 end

--- a/lib/n_plus_one_control/rspec/context.rb
+++ b/lib/n_plus_one_control/rspec/context.rb
@@ -3,17 +3,8 @@
 RSpec.shared_context "n_plus_one_control" do
   # Helper to access populate block from within example/matcher
   let(:n_plus_one_populate) do |ex|
-    if ex.example_group.populate.nil?
-      raise(
-        <<-MSG
-          Populate block is missing!
+    return if ex.example_group.populate.nil?
 
-          Please provide populate callback, e.g.:
-
-            populate { |n| n.times { create_some_stuff } }
-        MSG
-      )
-    end
     ->(n) { ex.instance_exec(n, &ex.example_group.populate) }
   end
 

--- a/lib/n_plus_one_control/rspec/dsl.rb
+++ b/lib/n_plus_one_control/rspec/dsl.rb
@@ -4,21 +4,29 @@ module NPlusOneControl
   module RSpec
     # Extends RSpec ExampleGroup with populate & warmup methods
     module DSL
-      # Setup warmup block, wich will run before matching
-      # for example, if using cache, then later queries
-      # will perform less DB queries than first
-      def warmup
-        return @warmup unless block_given?
+      module ClassMethods
+        # Setup warmup block, wich will run before matching
+        # for example, if using cache, then later queries
+        # will perform less DB queries than first
+        def warmup
+          return @warmup unless block_given?
 
-        @warmup = Proc.new
+          @warmup = Proc.new
+        end
+
+        # Setup populate callback, which is used
+        # to prepare data for each run.
+        def populate
+          return @populate unless block_given?
+
+          @populate = Proc.new
+        end
       end
 
-      # Setup populate callback, which is used
-      # to prepare data for each run.
-      def populate
-        return @populate unless block_given?
+      attr_accessor :executor
 
-        @populate = Proc.new
+      def scale
+        executor&.scale
       end
     end
   end

--- a/lib/n_plus_one_control/rspec/dsl.rb
+++ b/lib/n_plus_one_control/rspec/dsl.rb
@@ -2,8 +2,9 @@
 
 module NPlusOneControl
   module RSpec
-    # Extends RSpec ExampleGroup with populate & warmup methods
+    # Includes scale method into RSpec Example
     module DSL
+      # Extends RSpec ExampleGroup with populate & warmup methods
       module ClassMethods
         # Setup warmup block, wich will run before matching
         # for example, if using cache, then later queries

--- a/lib/n_plus_one_control/rspec/dsl.rb
+++ b/lib/n_plus_one_control/rspec/dsl.rb
@@ -26,8 +26,8 @@ module NPlusOneControl
 
       attr_accessor :executor
 
-      def scale
-        executor&.scale
+      def current_scale
+        executor&.current_scale
       end
     end
   end

--- a/lib/n_plus_one_control/rspec/matcher.rb
+++ b/lib/n_plus_one_control/rspec/matcher.rb
@@ -30,12 +30,13 @@
     # by default we're looking for select queries
     pattern = @pattern || /^SELECT/i
 
-    @queries = NPlusOneControl::Executor.call(
+    @matcher_execution_context.executor = NPlusOneControl::Executor.new(
       population: populate,
       matching: pattern,
-      scale_factors: @factors,
-      &actual
+      scale_factors: @factors
     )
+
+    @queries = @matcher_execution_context.executor.call(&actual)
 
     counts = @queries.map(&:last).map(&:size)
 

--- a/spec/n_plus_one_control/executor_spec.rb
+++ b/spec/n_plus_one_control/executor_spec.rb
@@ -12,20 +12,12 @@ describe NPlusOneControl::Executor do
   end
 
   it "raises when block is missing" do
-    expect { described_class.call(population: populate) }
+    expect { described_class.new(population: populate).call }
       .to raise_error(ArgumentError, "Block is required!")
   end
 
-  it "raises when populate is missing" do
-    expect { described_class.call(&observable) }
-      .to raise_error(ArgumentError, /population/)
-  end
-
   it "returns correct counts for default scales" do
-    result = described_class.call(
-      population: populate,
-      &observable
-    )
+    result = described_class.new(population: populate).call(&observable)
 
     expect(result.size).to eq 2
     expect(result.first[0]).to eq 2
@@ -35,11 +27,10 @@ describe NPlusOneControl::Executor do
   end
 
   it "returns correct counts for custom scales" do
-    result = described_class.call(
+    result = described_class.new(
       population: populate,
-      scale_factors: [5, 10, 100],
-      &observable
-    )
+      scale_factors: [5, 10, 100]
+    ).call(&observable)
 
     expect(result.size).to eq 3
     expect(result.first[0]).to eq 5
@@ -51,11 +42,10 @@ describe NPlusOneControl::Executor do
   end
 
   it "returns correct counts with custom match" do
-    result = described_class.call(
+    result = described_class.new(
       population: populate,
-      matching: /users/,
-      &observable
-    )
+      matching: /users/
+    ).call(&observable)
 
     expect(result.first[0]).to eq 2
     expect(result.first[1].size).to eq 2

--- a/spec/n_plus_one_control/rspec_spec.rb
+++ b/spec/n_plus_one_control/rspec_spec.rb
@@ -100,13 +100,13 @@ describe NPlusOneControl::RSpec do
     end
   end
 
-  context 'with usage of scale instead of populate', :n_plus_one do
-    it "can use current scale", :aggregate_failures do
+  context 'with usage of current_scale instead of populate', :n_plus_one do
+    it "can use current current_scale", :aggregate_failures do
       NPlusOneControl.default_scale_factors.each do |scale_factor|
         expect(Post).to receive(:limit).with(scale_factor).once
       end
 
-      expect { Post.limit(scale) }.to perform_constant_number_of_queries
+      expect { Post.limit(current_scale) }.to perform_constant_number_of_queries
     end
   end
 end

--- a/spec/n_plus_one_control/rspec_spec.rb
+++ b/spec/n_plus_one_control/rspec_spec.rb
@@ -95,15 +95,17 @@ describe NPlusOneControl::RSpec do
     populate { |n| create_list(:post, n) }
 
     it "runs actual one more time" do
-      expect(Post).to receive(:all).exactly(3).times
+      expect(Post).to receive(:all).exactly(NPlusOneControl.default_scale_factors.size + 1).times
       expect { Post.all }.to perform_constant_number_of_queries.with_warming_up
     end
   end
 
   context 'with usage of scale instead of populate', :n_plus_one do
     it "can use current scale", :aggregate_failures do
-      expect(Post).to receive(:limit).with(2).once
-      expect(Post).to receive(:limit).with(3).once
+      NPlusOneControl.default_scale_factors.each do |scale_factor|
+        expect(Post).to receive(:limit).with(scale_factor).once
+      end
+
       expect { Post.limit(scale) }.to perform_constant_number_of_queries
     end
   end

--- a/tests/minitest_test.rb
+++ b/tests/minitest_test.rb
@@ -60,4 +60,13 @@ class TestMinitest < Minitest::Test
 
     assert_match "Expected to make the same number of queries", e.message
   end
+
+  def test_scale_avalability
+    mock = Minitest::Mock.new
+    NPlusOneControl.default_scale_factors.each do |scale_factor|
+      mock.expect :limit, nil, [scale_factor]
+    end
+
+    assert_perform_constant_number_of_queries { mock.limit(scale) }
+  end
 end

--- a/tests/minitest_test.rb
+++ b/tests/minitest_test.rb
@@ -61,12 +61,12 @@ class TestMinitest < Minitest::Test
     assert_match "Expected to make the same number of queries", e.message
   end
 
-  def test_scale_avalability
+  def test_current_scale_avalability
     mock = Minitest::Mock.new
     NPlusOneControl.default_scale_factors.each do |scale_factor|
       mock.expect :limit, nil, [scale_factor]
     end
 
-    assert_perform_constant_number_of_queries { mock.limit(scale) }
+    assert_perform_constant_number_of_queries { mock.limit(current_scale) }
   end
 end


### PR DESCRIPTION
Hey Vladimir!

Thanks for the gem. I've found one potential performance improvement:

In some cases we are able to manage the number of records through parameters of the request, for example, when we have pagination:

```ruby
get :index, params: { per_page: 10 }
```

or in GraphQL:

```graphql
query {
  posts(limit: 10) { id }
}
```

In those cases we don't need to recreate records before each run of `actual` block and can manage it as in the example.
For this purpose I've added `scale` method, which is an alias to current scale factor of executor. Supposed usage:

```ruby
context "N+1", :n_plus_one do
  specify do
    expect { get :index, params: { per_page: scale } }.to perform_constant_number_of_queries
  end
end
```
