### PR TITLE
Support table names surrounded by backtick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master (unreleased)
 
+- Fix table stats summary when queries use backticks to surround table names ([@andrewhampton])
+
 ## 0.5.0 (2020-09-07)
 
 - **Ruby 2.5+ is required**. ([@palkan][])

--- a/lib/n_plus_one_control.rb
+++ b/lib/n_plus_one_control.rb
@@ -6,7 +6,7 @@ require "n_plus_one_control/executor"
 # RSpec and Minitest matchers to prevent N+1 queries problem.
 module NPlusOneControl
   # Used to extract a table name from a query
-  EXTRACT_TABLE_RXP = /(insert into|update|delete from|from) ['"](\S+)['"]/i.freeze
+  EXTRACT_TABLE_RXP = /(insert into|update|delete from|from) ['"`](\S+)['"`]/i.freeze
 
   # Used to convert a query part extracted by the regexp above to the corresponding
   # human-friendly type


### PR DESCRIPTION
## What is the purpose of this pull request?

In our rails app, the query looks like this:

```sql
SELECT `users`.* FROM `users` WHERE `users`.`account_id` = 1 AND `users`.`id` = 1 LIMIT 1
```

This PR adds support for table names surrounded by backticks in addition to the current support for single and double quotes.

## What changes did you make? (overview)

Slight tweak to the `EXTRACT_TABLE_RXP` regular expression.

## Is there anything you'd like reviewers to focus on?

## Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] ~I've updated a documentation~ not applicable
