### PR TITLE
Prepare to accept custom Collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change log
 
-## master
+## v1-dev
+
+- Add possibility to create custom collectors ([@Earendil95][])
 
 ## 0.6.2 (2021-10-26)
 
@@ -44,3 +46,4 @@ Could be specified via `NPLUSONE_BACKTRACE` env var.
 [@palkan]: https://github.com/palkan
 [@caalberts]: https://github.com/caalberts
 [@andrewhampton]: https://github.com/andrewhampton
+[@mrzasa]: https://github.com/mrzasa

--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ If your `warmup` and testing procs are identical, you can use:
 expext { get :index }.to perform_constant_number_of_queries.with_warming_up # RSpec only
 ```
 
+### Non-SQL events
+
+Read, how to add support for your own event, such as external HTTP request, complex logic or whatever else [here](./custom-collectors.md)
+
 ### Configuration
 
 There are some global configuration parameters (and their corresponding defaults):

--- a/custom-collectors.md
+++ b/custom-collectors.md
@@ -1,0 +1,127 @@
+## Building a custom collector
+
+By default, `n_plus_one_control` checks for N+1 database calls, but what if we want to make sure, for example, that we make constant number of HTTP calls? For this purpose, we can build a custom Collector class.
+
+Let's say, we have a Rails application, that has some client:
+```ruby
+class ExternalClient
+  def self.request(url)
+    # call http, process the response, etc.
+  end
+end
+```
+
+First thing we need to do is to add a notification that we perfom a request:
+```ruby
+class ExternalClient
+  def self.request(url)
+    ActiveSupport::Notifications.instrument('external_client.http', url: url)
+    # call http, process the response, etc.
+  end
+end
+```
+
+Now, in tests, we can subscribe to this event and count, how many times http was called.
+
+To do so, we define a new class:
+```ruby
+class HTTPCollector < NPlusOneControl::Collectors::Base
+  self.key = :http # This key we will be using later in tests
+  self.name = 'HTTP' # Optional; used for error message. If omitted, will default to `key.to_s.upcase`
+  self.event = 'external_client.http' # This is the event we created above
+  # You can also make event dynamic by passing a proc here, like:
+  # self.event = -> { fetch_event_name }
+
+  def callback(*, payload) # See ActiveSupport::Notifications docs to learn about other params
+    # Put something to `@queries`; In matchers, we rely on its size.
+    @queries << payload[:url]
+  end
+end
+
+NPlusOneControl::CollectorsRegistry.register(HTTPCollector)
+```
+
+Now, let's say we have some model, that can call the client to get some data:
+```ruby
+class Record < ApplicationRecord
+  def externa_data
+    @data ||= ExternalClient.request("domain.com/record?ids=#{id}")
+  end
+
+  def cache_data(data)
+    @data = data
+  end
+end
+```
+
+Whenever we have several record ids and need to get that external data, we have several options:
+```ruby
+# 1. N+1
+Record.find(ids).map(external_data)
+
+# 2. No N+1
+data = ExternalClient.request("domain.com/record?ids=#{ids.join(',')}") # Yes, quite a simplified example, but still
+Record.find(ids).each { |record| record.cache_data(data.fetch(record.id)) }
+```
+
+Of course, we prefer the second way without N+1 HTTP requests. Now, to make sure we use it, we can write a test:
+
+```ruby
+# RSpec
+context "N+1", :n_plus_one do
+  specify do
+    expect { some_code_triggering_possible_n_plus_one }.to perform_constant_number_of_queries.to(:http)
+  end
+end
+
+# Minitiest
+def test_no_n_plus_one_http
+  assert_perform_constant_number_of_queries(collectors: :http) do
+    some_code_triggering_possible_n_plus_one
+  end
+end
+```
+
+We may also extend this test to check _both_ HTTP _and_ DB queries:
+```ruby
+# RSpec
+context "N+1", :n_plus_one do
+  specify do
+    expect { some_code_triggering_possible_n_plus_one }.to perform_constant_number_of_queries.to(:db, :http)
+  end
+end
+
+# Minitiest
+def test_no_n_plus_one_http
+  assert_perform_constant_number_of_queries(collectors: %i[http db]) do
+    some_code_triggering_possible_n_plus_one
+  end
+end
+```
+
+**NOTE**: this also works with `perform_linear_number_of_queries` and `assert_perform_linear_number_of_queries`.
+
+### Error message
+
+By default, your custom collector will show a very minimal information in error message, only amount of calls for each N. You can enrich it by redefining `failure_message` method in the collector class:
+```ruby
+class HTTPCollector
+  def self.failure_message(_, queries)
+    msg = super
+
+    if NPlusOneControl.verbose
+      queries.each do |(scale, data)|
+        msg << "Queries for N=#{scale}\n"
+
+        # `data[:http]` contains everything we were putting to `@queries` in the `callback` method for the given scale.
+        # In our case, it is URLs that we request
+        msg << data[:http].map { |url| "  #{url}\n" }.join.to_s
+      end
+    end
+
+    msg
+  end
+end
+```
+
+With this enhancement, error message will also contain all the URLs we requested for every scale factor.

--- a/lib/n_plus_one_control/collectors/base.rb
+++ b/lib/n_plus_one_control/collectors/base.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module NPlusOneControl
+  module Collectors
+    class Base
+      class << self
+        attr_accessor :key, :event, :name
+
+        def failure_message(type, queries)
+          msg = ["#{::NPlusOneControl::FAILURE_MESSAGES[type]} to #{name || key.to_s.upcase}, but got:\n"]
+          queries.each do |(scale, data)|
+            msg << "  #{data[key].size} for N=#{scale}\n"
+          end
+          msg.join
+        end
+      end
+
+      def initialize(pattern)
+        @pattern = pattern
+        @queries = []
+      end
+
+      def subscribe
+        event = self.class.event.respond_to?(:call) ? self.class.event.call : self.class.event
+        @subscriber = ActiveSupport::Notifications.subscribe(event, method(:callback))
+      end
+
+      def reset
+        unsubscribe
+        @queries = []
+      end
+
+      def callback
+        raise NotImplementedError
+      end
+
+      private
+
+      def unsubscribe
+        ActiveSupport::Notifications.unsubscribe(@subscriber)
+      end
+    end
+  end
+end

--- a/lib/n_plus_one_control/collectors/db.rb
+++ b/lib/n_plus_one_control/collectors/db.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "n_plus_one_control/collectors_registry"
+require "n_plus_one_control/collectors/base"
+
+module NPlusOneControl
+  module Collectors
+    class DB < Base
+      class << self
+        # Used to convert a query part extracted by the regexp above to the corresponding
+        # human-friendly type
+        QUERY_PART_TO_TYPE = {
+          "insert into" => "INSERT",
+          "update" => "UPDATE",
+          "delete from" => "DELETE",
+          "from" => "SELECT"
+        }.freeze
+
+        # This method enriches default error message with table usage stats
+        def failure_message(_, queries)
+          msg = super
+
+          msg << table_usage_stats(queries.map(&:last)) if NPlusOneControl.show_table_stats
+
+          if NPlusOneControl.verbose
+            queries.each do |(scale, data)|
+              msg << "Queries for N=#{scale}\n"
+              msg << data[key].map { |sql| "  #{truncate_query(sql)}\n" }.join.to_s
+            end
+          end
+
+          msg
+        end
+
+        private
+
+        def table_usage_stats(runs) # rubocop:disable Metrics/MethodLength
+          msg = ["Unmatched query numbers by tables:\n"]
+
+          before, after = runs.map do |queries|
+            queries[key].group_by do |query|
+              matches = query.match(EXTRACT_TABLE_RXP)
+              next unless matches
+
+              "  #{matches[2]} (#{QUERY_PART_TO_TYPE[matches[1].downcase]})"
+            end.transform_values(&:count)
+          end
+
+          before.keys.each do |k|
+            next if before[k] == after[k]
+
+            msg << "#{k}: #{before[k]} != #{after[k]}\n"
+          end
+
+          msg.join
+        end
+
+        def truncate_query(sql)
+          return sql unless NPlusOneControl.truncate_query_size
+
+          # Only truncate query, leave tracing (if any) as is
+          parts = sql.split(/(\s+↳)/)
+
+          parts[0] =
+            if NPlusOneControl.truncate_query_size < 4
+              "..."
+            else
+              parts[0][0..(NPlusOneControl.truncate_query_size - 4)] + "..."
+            end
+
+          parts.join
+        end
+      end
+
+      attr_reader :queries
+
+      self.key = :db
+      self.name = "database"
+      self.event = -> { NPlusOneControl.event }
+
+      def callback(_name, _start, _finish, _message_id, values) # rubocop:disable Metrics/CyclomaticComplexity,Layout/LineLength
+        return if %w[CACHE SCHEMA].include? values[:name]
+        return if values[:sql].match?(NPlusOneControl.ignore)
+
+        return unless @pattern.nil? || (values[:sql] =~ @pattern)
+
+        query = values[:sql]
+
+        if NPlusOneControl.backtrace_cleaner && NPlusOneControl.verbose
+          source = extract_query_source_location(caller)
+
+          query = "#{query}\n    ↳ #{source.join("\n")}" unless source.empty?
+        end
+
+        @queries << query
+      end
+
+      private
+
+      def extract_query_source_location(locations)
+        NPlusOneControl.backtrace_cleaner.call(locations.lazy)
+          .take(NPlusOneControl.backtrace_length).to_a
+      end
+    end
+  end
+end
+
+NPlusOneControl::CollectorsRegistry.register(NPlusOneControl::Collectors::DB)

--- a/lib/n_plus_one_control/collectors_registry.rb
+++ b/lib/n_plus_one_control/collectors_registry.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module NPlusOneControl
+  class CollectorsRegistry
+    class << self
+      def register(collector_class)
+        @collectors ||= {}
+        @collectors[collector_class.key] = collector_class
+      end
+
+      def slice(*keys)
+        raise ArgumentError, <<~MSG unless (keys & collectors.keys).size == keys.size
+          No collectors for keys: #{keys.join(", ")}, exsiting collectors are: #{collectors.keys.join(", ")}
+        MSG
+
+        collectors.slice(*keys)
+      end
+
+      def get(key)
+        collectors.fetch(key)
+      end
+
+      def unregister(*classes)
+        classes.each { |klass| collectors.delete(klass.key) }
+      end
+
+      private
+
+      attr_reader :collectors
+    end
+  end
+end

--- a/lib/n_plus_one_control/rspec.rb
+++ b/lib/n_plus_one_control/rspec.rb
@@ -16,4 +16,6 @@ end
 ::RSpec.configure do |config|
   config.extend NPlusOneControl::RSpec::DSL::ClassMethods, n_plus_one: true
   config.include NPlusOneControl::RSpec::DSL, n_plus_one: true
+
+  config.example_status_persistence_file_path = "tmp/rspec_results"
 end

--- a/spec/n_plus_one_control/collectors_registry_spec.rb
+++ b/spec/n_plus_one_control/collectors_registry_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe NPlusOneControl::CollectorsRegistry do
+  describe ".register" do
+    subject(:register) { described_class.register(test_collector) }
+
+    after { described_class.unregister(test_collector) }
+
+    let(:test_collector) { Struct.new(:key).new(:__test_register) }
+
+    specify do
+      register
+      expect(described_class.get(:__test_register)).to eq(test_collector)
+    end
+  end
+
+  describe ".slice" do
+    subject(:sliced_collectors) { described_class.slice(*collector_keys) }
+
+    let(:collector_keys) { [:db] }
+
+    specify { expect(sliced_collectors).to eq(db: ::NPlusOneControl::Collectors::DB) }
+
+    context "when undefined key passed" do
+      let(:collector_keys) { [:__test_slice_undefined_key] }
+
+      specify { expect { sliced_collectors }.to raise_error(ArgumentError, /: __test_slice_undefined_key, exsiting collectors are: db/) }
+    end
+  end
+end

--- a/spec/n_plus_one_control/executor_spec.rb
+++ b/spec/n_plus_one_control/executor_spec.rb
@@ -16,17 +16,17 @@ describe NPlusOneControl::Executor do
       .to raise_error(ArgumentError, "Block is required!")
   end
 
-  it "returns correct counts for default scales" do
+  it "returns correct counts for default scales", :aggregate_failures do
     result = described_class.new(population: populate).call(&observable)
 
     expect(result.size).to eq 2
     expect(result.first[0]).to eq 2
-    expect(result.first[1].size).to eq 3
+    expect(result.first[1][:db].size).to eq 3
     expect(result.last[0]).to eq 3
-    expect(result.last[1].size).to eq 4
+    expect(result.last[1][:db].size).to eq 4
   end
 
-  it "returns correct counts for custom scales" do
+  it "returns correct counts for custom scales", :aggregate_failures do
     result = described_class.new(
       population: populate,
       scale_factors: [5, 10, 100]
@@ -34,23 +34,23 @@ describe NPlusOneControl::Executor do
 
     expect(result.size).to eq 3
     expect(result.first[0]).to eq 5
-    expect(result.first[1].size).to eq 6
+    expect(result.first[1][:db].size).to eq 6
     expect(result.second[0]).to eq 10
-    expect(result.second[1].size).to eq 11
+    expect(result.second[1][:db].size).to eq 11
     expect(result.last[0]).to eq 100
-    expect(result.last[1].size).to eq 101
+    expect(result.last[1][:db].size).to eq 101
   end
 
-  it "returns correct counts with custom match" do
+  it "returns correct counts with custom match", :aggregate_failures do
     result = described_class.new(
       population: populate,
       matching: /users/
     ).call(&observable)
 
     expect(result.first[0]).to eq 2
-    expect(result.first[1].size).to eq 2
+    expect(result.first[1][:db].size).to eq 2
     expect(result.last[0]).to eq 3
-    expect(result.last[1].size).to eq 3
+    expect(result.last[1][:db].size).to eq 3
   end
 
   context "with .ignore set" do
@@ -66,9 +66,23 @@ describe NPlusOneControl::Executor do
         population: populate
       ).call(&observable)
       expect(result.first[0]).to eq 2
-      expect(result.first[1].size).to eq 2
+      expect(result.first[1][:db].size).to eq 2
       expect(result.last[0]).to eq 3
-      expect(result.last[1].size).to eq 3
+      expect(result.last[1][:db].size).to eq 3
+    end
+  end
+
+  context "with several collectors", :n_plus_one do
+    before { NPlusOneControl::CollectorsRegistry.register(another_collector) }
+    after { NPlusOneControl::CollectorsRegistry.unregister(another_collector) }
+
+    let(:another_collector) { NPlusOneControl::Collectors::DB.dup.tap { |collector| collector.key = :another_collector } }
+
+    # Here, we test that number of actual proc runs doesn't depend on amount of collectors.
+    # There is no better way than test it via our matcher :D
+    it "runs block only once" do
+      expect { described_class.new.call(collectors: %i[db another_collector].first(current_scale), &observable) }
+        .to perform_constant_number_of_queries.with_scale_factors(1, 2)
     end
   end
 end

--- a/spec/n_plus_one_control/rspec/matchers/perform_constant_number_of_queries_spec.rb
+++ b/spec/n_plus_one_control/rspec/matchers/perform_constant_number_of_queries_spec.rb
@@ -3,187 +3,236 @@
 require "spec_helper"
 
 describe NPlusOneControl::RSpec do
-  context "when no N+1", :n_plus_one do
-    populate { |n| create_list(:post, n) }
+  describe "perform_constant_number_of_queries" do
+    context "when no N+1", :n_plus_one do
+      populate { |n| create_list(:post, n) }
 
-    specify do
-      expect { Post.preload(:user).find_each { |p| p.user.name } }
-        .to perform_constant_number_of_queries
-    end
-  end
-
-  context "when has N+1", :n_plus_one do
-    populate { |n| create_list(:post, n) }
-
-    specify do
-      expect do
-        expect { Post.find_each { |p| p.user.name } }
+      specify do
+        expect { Post.preload(:user).find_each { |p| p.user.name } }
           .to perform_constant_number_of_queries
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
-    end
-  end
-
-  context "when context is missing" do
-    specify do
-      expect do
-        expect { subject }.to perform_constant_number_of_queries
-      end.to raise_error(/missing tag/i)
-    end
-  end
-
-  context "when negated" do
-    specify do
-      expect do
-        expect { subject }.not_to perform_constant_number_of_queries
-      end.to raise_error(/support negation/i)
-    end
-  end
-
-  context "when actual block fails", :n_plus_one do
-    specify do
-      expect do
-        expect { expect(1).to eq(0) }.to perform_constant_number_of_queries
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected: 0\n\s+got: 1/)
-    end
-  end
-
-  context "when verbose", :n_plus_one do
-    populate { |n| create_list(:post, n) }
-
-    around(:each) do |ex|
-      NPlusOneControl.verbose = true
-      ex.run
-      NPlusOneControl.verbose = false
+      end
     end
 
-    specify do
-      expect do
-        expect { Post.find_each { |p| p.user.name } }
-          .to perform_constant_number_of_queries
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /select .+ from.*↳ .*_spec.rb:\d+/im)
+    context "when has N+1", :n_plus_one do
+      populate { |n| create_list(:post, n) }
+
+      specify do
+        expect do
+          expect { Post.find_each { |p| p.user.name } }
+            .to perform_constant_number_of_queries
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+      end
     end
 
-    context "when truncate size is specified" do
+    context "when context is missing" do
+      specify do
+        expect do
+          expect { subject }.to perform_constant_number_of_queries
+        end.to raise_error(/missing tag/i)
+      end
+    end
+
+    context "when negated" do
+      specify do
+        expect do
+          expect { subject }.not_to perform_constant_number_of_queries
+        end.to raise_error(/support negation/i)
+      end
+    end
+
+    context "when actual block fails", :n_plus_one do
+      specify do
+        expect do
+          expect { expect(1).to eq(0) }.to perform_constant_number_of_queries
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected: 0\n\s+got: 1/)
+      end
+    end
+
+    context "when verbose", :n_plus_one do
       populate { |n| create_list(:post, n) }
 
       around(:each) do |ex|
-        NPlusOneControl.truncate_query_size = 6
+        NPlusOneControl.verbose = true
         ex.run
-        NPlusOneControl.truncate_query_size = nil
+        NPlusOneControl.verbose = false
       end
 
       specify do
         expect do
           expect { Post.find_each { |p| p.user.name } }
             .to perform_constant_number_of_queries
-        end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /sel\.\.\./i)
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /select .+ from.*↳ .*_spec.rb:\d+/im)
+      end
+
+      context "when truncate size is specified" do
+        populate { |n| create_list(:post, n) }
+
+        around(:each) do |ex|
+          NPlusOneControl.truncate_query_size = 6
+          ex.run
+          NPlusOneControl.truncate_query_size = nil
+        end
+
+        specify do
+          expect do
+            expect { Post.find_each { |p| p.user.name } }
+              .to perform_constant_number_of_queries
+          end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /sel\.\.\./i)
+        end
+      end
+
+      context "when backtrace length is specified" do
+        populate { |n| create_list(:post, n) }
+
+        around(:each) do |ex|
+          NPlusOneControl.backtrace_length = 2
+          ex.run
+          NPlusOneControl.backtrace_length = 1
+        end
+
+        specify do
+          expect do
+            expect { Post.find_each { |p| p.user.name } }
+              .to perform_constant_number_of_queries
+          end.to raise_error(
+            RSpec::Expectations::ExpectationNotMetError,
+            /select .+ from.*↳.*_spec.rb:\d+.*\n.*_spec.rb:\d+/im
+          )
+        end
       end
     end
 
-    context "when backtrace length is specified" do
+    context "with table stats", :n_plus_one do
       populate { |n| create_list(:post, n) }
 
       around(:each) do |ex|
-        NPlusOneControl.backtrace_length = 2
+        NPlusOneControl.show_table_stats = true
         ex.run
-        NPlusOneControl.backtrace_length = 1
+        NPlusOneControl.show_table_stats = false
       end
 
       specify do
         expect do
           expect { Post.find_each { |p| p.user.name } }
             .to perform_constant_number_of_queries
-        end.to raise_error(
-          RSpec::Expectations::ExpectationNotMetError,
-          /select .+ from.*↳.*_spec.rb:\d+.*\n.*_spec.rb:\d+/im
-        )
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /users \(SELECT\): 2 != 3/i)
       end
     end
-  end
 
-  context "with table stats", :n_plus_one do
-    populate { |n| create_list(:post, n) }
+    context "with scale_factors", :n_plus_one do
+      populate { |n| create_list(:post, n) }
 
-    around(:each) do |ex|
-      NPlusOneControl.show_table_stats = true
-      ex.run
-      NPlusOneControl.show_table_stats = false
-    end
-
-    specify do
-      expect do
-        expect { Post.find_each { |p| p.user.name } }
-          .to perform_constant_number_of_queries
-      end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /users \(SELECT\): 2 != 3/i)
-    end
-  end
-
-  context "with scale_factors", :n_plus_one do
-    populate { |n| create_list(:post, n) }
-
-    specify do
-      expect { Post.preload(:user).find_each { |p| p.user.name } }
-        .to perform_constant_number_of_queries.with_scale_factors(1, 2)
-    end
-  end
-
-  context "with matching", :n_plus_one do
-    populate { |n| create_list(:post, n) }
-
-    specify do
-      expect { Post.find_each { |p| p.user.name } }
-        .to perform_constant_number_of_queries.matching(/posts/)
-    end
-
-    context "with matching is provided globally", :n_plus_one do
-      around(:each) do |ex|
-        NPlusOneControl.default_matching = "posts"
-        ex.run
-        NPlusOneControl.default_matching = nil
+      specify do
+        expect { Post.preload(:user).find_each { |p| p.user.name } }
+          .to perform_constant_number_of_queries.with_scale_factors(1, 2)
       end
+    end
 
+    context "with matching", :n_plus_one do
       populate { |n| create_list(:post, n) }
 
       specify do
         expect { Post.find_each { |p| p.user.name } }
-          .to perform_constant_number_of_queries
-      end
-    end
-  end
-
-  context "with warming up", :n_plus_one do
-    let(:cache) { double "cache" }
-
-    before do
-      allow(cache).to receive(:setup).and_return(:result)
-    end
-
-    populate { |n| create_list(:post, n) }
-
-    warmup { cache.setup }
-
-    it "runs warmup before calling Executor" do
-      expect(cache).to receive(:setup)
-      expect { Post.find_each(&:id) }.to perform_constant_number_of_queries
-    end
-  end
-
-  context "with_warming_up", :n_plus_one do
-    populate { |n| create_list(:post, n) }
-
-    it "runs actual one more time" do
-      expect(Post).to receive(:all).exactly(NPlusOneControl.default_scale_factors.size + 1).times
-      expect { Post.all }.to perform_constant_number_of_queries.with_warming_up
-    end
-  end
-
-  context "with usage of current_scale instead of populate", :n_plus_one do
-    it "can use current current_scale", :aggregate_failures do
-      NPlusOneControl.default_scale_factors.each do |scale_factor|
-        expect(Post).to receive(:limit).with(scale_factor).once
+          .to perform_constant_number_of_queries.matching(/posts/)
       end
 
-      expect { Post.limit(current_scale) }.to perform_constant_number_of_queries
+      context "with matching is provided globally", :n_plus_one do
+        around(:each) do |ex|
+          old_matching = NPlusOneControl.default_matching
+          NPlusOneControl.default_matching = "posts"
+          ex.run
+          NPlusOneControl.default_matching = old_matching
+        end
+
+        populate { |n| create_list(:post, n) }
+
+        specify do
+          expect { Post.find_each { |p| p.user.name } }
+            .to perform_constant_number_of_queries
+        end
+      end
+    end
+
+    context "with warming up", :n_plus_one do
+      let(:cache) { double "cache" }
+
+      before do
+        allow(cache).to receive(:setup).and_return(:result)
+      end
+
+      populate { |n| create_list(:post, n) }
+
+      warmup { cache.setup }
+
+      it "runs warmup before calling Executor" do
+        expect(cache).to receive(:setup)
+        expect { Post.find_each(&:id) }.to perform_constant_number_of_queries
+      end
+    end
+
+    context "with_warming_up", :n_plus_one do
+      populate { |n| create_list(:post, n) }
+
+      it "runs actual one more time" do
+        expect(Post).to receive(:all).exactly(NPlusOneControl.default_scale_factors.size + 1).times
+        expect { Post.all }.to perform_constant_number_of_queries.with_warming_up
+      end
+    end
+
+    context "with usage of current_scale instead of populate", :n_plus_one do
+      it "can use current current_scale", :aggregate_failures do
+        NPlusOneControl.default_scale_factors.each do |scale_factor|
+          expect(Post).to receive(:limit).with(scale_factor).once
+        end
+
+        expect { Post.limit(current_scale) }.to perform_constant_number_of_queries
+      end
+    end
+
+    context "with custom collector" do
+      before { NPlusOneControl::CollectorsRegistry.register(another_collector) }
+      after { NPlusOneControl::CollectorsRegistry.unregister(another_collector) }
+
+      let(:another_collector) do
+        NPlusOneControl::Collectors::DB.dup.tap do |collector|
+          collector.key = :secondary_db
+          collector.name = nil
+          collector.event = "sql.active_record"
+        end
+      end
+
+      context "when no N+1", :n_plus_one do
+        populate { |n| create_list(:post, n) }
+
+        specify do
+          expect { Post.preload(:user).find_each { |p| p.user.name } }
+            .to perform_constant_number_of_queries.to(:secondary_db)
+        end
+      end
+
+      context "when has N+1", :n_plus_one do
+        populate { |n| create_list(:post, n) }
+
+        specify do
+          expect do
+            expect { Post.find_each { |p| p.user.name } }
+              .to perform_constant_number_of_queries.to(:secondary_db)
+          end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /SECONDARY_DB/)
+        end
+      end
+
+      context "when collector has name", :n_plus_one do
+        before { another_collector.name = "secondary database" }
+
+        populate { |n| create_list(:post, n) }
+
+        specify do
+          expect do
+            expect { Post.find_each { |p| p.user.name } }
+              .to perform_constant_number_of_queries.to(:secondary_db)
+          end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /secondary database/)
+        end
+      end
     end
   end
 end

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -8,6 +8,10 @@ end
 
 class User < ActiveRecord::Base
   has_many :posts
+
+  def external_call
+    ActiveSupport::Notifications.instrument("n_plus_one_control.external_event") { true }
+  end
 end
 
 FactoryGirl.define do


### PR DESCRIPTION
## What is the purpose of this pull request?

From [README.md](./README.md):
> N+1 problem is not a database specific: we can have N+1 Redis calls, N+1 HTTP external requests, etc.
> We can make `n_plus_one_control` customizable to support these scenarios (technically, we need to make it possible to handle different payload in the event subscriber).

This PR is going to add an ability to create custom Collectors so we can track N+1 "everywhere, for everyone, forever" (c).

## What changes did you make? (overview)

## Is there anything you'd like reviewers to focus on?

Not yet. This PR currently makes it easier to track my progress.

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
