### PR TITLE
Do not count a query matching .ignore pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fix .ignore setting (.ignore setting was ignored by the Collector ;-))
+
 ## 0.6.1 (2021-03-05)
 
 - Ruby 3.0 compatibility. ([@palkan][])

--- a/lib/n_plus_one_control/executor.rb
+++ b/lib/n_plus_one_control/executor.rb
@@ -21,6 +21,7 @@ module NPlusOneControl
 
       def callback(_name, _start, _finish, _message_id, values) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/LineLength
         return if %w[CACHE SCHEMA].include? values[:name]
+        return if values[:sql].match?(NPlusOneControl.ignore)
 
         return unless @pattern.nil? || (values[:sql] =~ @pattern)
 

--- a/spec/n_plus_one_control/executor_spec.rb
+++ b/spec/n_plus_one_control/executor_spec.rb
@@ -52,4 +52,23 @@ describe NPlusOneControl::Executor do
     expect(result.last[0]).to eq 3
     expect(result.last[1].size).to eq 3
   end
+
+  context "with .ignore set" do
+    around do |example|
+      old_ignore = NPlusOneControl.ignore
+      NPlusOneControl.ignore = /^SELECT\s+"posts"\.\*\s+FROM\s+"posts"/
+      example.call
+      NPlusOneControl.ignore = old_ignore
+    end
+
+    it "ignores queries matching .ignore regex" do
+      result = described_class.new(
+        population: populate
+      ).call(&observable)
+      expect(result.first[0]).to eq 2
+      expect(result.first[1].size).to eq 2
+      expect(result.last[0]).to eq 3
+      expect(result.last[1].size).to eq 3
+    end
+  end
 end


### PR DESCRIPTION
## What is the purpose of this pull request?

There is a setting `NPlusOneControl.ignore` that is documented but not used.

## What changes did you make? (overview)

I added a guard clause to `Executor::Collector` that skips queries matching the ignore pattern

## Is there anything you'd like reviewers to focus on?

Two questions for potential future improvements (I may provide them as follow-up PRs)
1. Could we use an array for ignore instead of a single regex? That'd be easier to write, would potentially run faster  (regex alternative isn't the most performant thing) and would be aligned with [`DBQueryMatchers`](https://github.com/civiccc/db-query-matchers#configuration) so it'd be easier to keep those two configs in sync (or to migrate).
2. What do you think about removing the global state (direct calls to `NPlusOneControl` constant) from the `Executor` and inject the config in the constructor? It may make testing easier and save us from concurrency issues. 

## Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry **Do we need that for a bugfix?**
- ~I've updated a documentation~ no need for that, it's a bugfix.
