### PR TITLE
Fix unobvious exception when inner block of rspec matcher fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 - Fix .ignore setting (.ignore setting was ignored by the Collector ;-))
+- Fix rspec matchers to allow expectations inside execution block
 
 ## 0.6.1 (2021-03-05)
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,20 @@ context "N+1", :n_plus_one do
 end
 ```
 
+### Expectations in execution block
+
+Both rspec matchers allows you to put additional expectations inside execution block to ensure that tested piece of code actually does what expected.
+
+```ruby
+context "N+1", :n_plus_one do
+  specify do
+    expect do
+      expect(my_query).to eq(actuall_results)
+    end.to perform_constant_number_of_queries
+  end
+end
+```
+
 #### Other available matchers
 
 `perform_linear_number_of_queries(slope: 1)` allows you to test that a query generates linear number of queries with the given slope.  

--- a/lib/n_plus_one_control/rspec/matchers/perform_constant_number_of_queries.rb
+++ b/lib/n_plus_one_control/rspec/matchers/perform_constant_number_of_queries.rb
@@ -16,7 +16,7 @@
     @warmup = true
   end
 
-  match do |actual, *_args|
+  match(notify_expectation_failures: true) do |actual, *_args|
     raise ArgumentError, "Block is required" unless actual.is_a? Proc
 
     raise "Missing tag :n_plus_one" unless

--- a/lib/n_plus_one_control/rspec/matchers/perform_linear_number_of_queries.rb
+++ b/lib/n_plus_one_control/rspec/matchers/perform_linear_number_of_queries.rb
@@ -16,7 +16,7 @@
     @warmup = true
   end
 
-  match do |actual, *_args|
+  match(notify_expectation_failures: true) do |actual, *_args|
     raise ArgumentError, "Block is required" unless actual.is_a? Proc
 
     raise "Missing tag :n_plus_one" unless

--- a/spec/n_plus_one_control/rspec/matchers/perform_constant_number_of_queries_spec.rb
+++ b/spec/n_plus_one_control/rspec/matchers/perform_constant_number_of_queries_spec.rb
@@ -39,6 +39,14 @@ describe NPlusOneControl::RSpec do
     end
   end
 
+  context "when actual block fails", :n_plus_one do
+    specify do
+      expect do
+        expect { expect(1).to eq(0) }.to perform_constant_number_of_queries
+      end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected: 0\n\s+got: 1/)
+    end
+  end
+
   context "when verbose", :n_plus_one do
     populate { |n| create_list(:post, n) }
 

--- a/spec/n_plus_one_control/rspec/matchers/perform_linear_number_of_queries_spec.rb
+++ b/spec/n_plus_one_control/rspec/matchers/perform_linear_number_of_queries_spec.rb
@@ -51,6 +51,14 @@ describe NPlusOneControl::RSpec do
       end
     end
 
+    context "when actual block fails expectations", :n_plus_one do
+      specify do
+        expect do
+          expect { expect(1).to eq(0) }.to perform_linear_number_of_queries
+        end.to raise_error(RSpec::Expectations::ExpectationNotMetError, /expected: 0\n\s+got: 1/)
+      end
+    end
+
     context "with scale_factors", :n_plus_one do
       populate { |n| create_list(:post, n) }
 


### PR DESCRIPTION
## What is the purpose of this pull request?

This is the fix for rspec matchers error when actial block (the one passed to `expect`) fails with ExpectationNotMetError. This error is swollowed by default and results in unobvious exception (something like NoMethodError each on NilClass which is caused by unset @queries variable).

## What changes did you make? (overview)

By adding `notify_expectation_failures: true` option to `match` macro in matcher definition we propagate ExpectationNotMetError from actual block.

## Is there anything you'd like reviewers to focus on?

Nothing in particular. THe fix is pretty small.

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
