### PR TITLE
Suppress warning in spec

### DIFF
--- a/spec/n_plus_one_control/rspec/matchers/perform_linear_number_of_queries_spec.rb
+++ b/spec/n_plus_one_control/rspec/matchers/perform_linear_number_of_queries_spec.rb
@@ -11,7 +11,7 @@ describe NPlusOneControl::RSpec do
         expect do
           expect { Post.preload(:user).find_each { |p| p.user.name } }
             .to perform_linear_number_of_queries(slope: 1)
-        end.not_to raise_error(RSpec::Expectations::ExpectationNotMetError)
+        end.not_to raise_error
       end
     end
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Suppress warning in spec

## What changes did you make? (overview)

Suppress the following warnings

```
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. `NoMethodError`, `NameError` and `ArgumentError`), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /home/runner/work/n_plus_one_control/n_plus_one_control/spec/n_plus_one_control/rspec/matchers/perform_linear_number_of_queries_spec.rb:11:in `block (4 levels) in <top (required)>'.
```