### PR TITLE
Add Ruby 3.1 and Rails 7 to the CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,17 +16,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7"]
-        gemfile: ["gemfiles/rails6.gemfile"]
+        ruby: ["2.7", "3.0"]
+        gemfile: ["gemfiles/rails6.gemfile", "gemfiles/rails7.gemfile"]
         include:
         - ruby: "2.5"
           gemfile: "gemfiles/rails5.gemfile"
         - ruby: "2.6"
           gemfile: "gemfiles/rails5.gemfile"
-        - ruby: "2.7"
-          gemfile: "gemfiles/railsmaster.gemfile"
         - ruby: "3.0"
-          gemfile: "gemfiles/rails6.gemfile"
+          gemfile: "gemfiles/railsmaster.gemfile"
+        - ruby: "3.1"
+          gemfile: "gemfiles/rails7.gemfile"
+        - ruby: "3.1"
+          gemfile: "gemfiles/railsmaster.gemfile"
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v1

--- a/gemfiles/rails7.gemfile
+++ b/gemfiles/rails7.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gem 'activerecord', '~> 7.0'
+gem 'sqlite3', '~> 1.4.0'
+
+gemspec path: '..'

--- a/n_plus_one_control.gemspec
+++ b/n_plus_one_control.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", ">= 13.0"
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "minitest", "~> 5.9"
-  spec.add_development_dependency "factory_girl", "~> 4.8.0"
+  spec.add_development_dependency "factory_bot", "~> 6.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ end
 require "n_plus_one_control/rspec"
 require "benchmark"
 require "active_record"
-require "factory_girl"
+require "factory_bot"
 
 NPlusOneControl.backtrace_cleaner = ->(locations) { locations.grep(/#{__dir__}\//) }
 
@@ -23,7 +23,7 @@ RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   config.before(:each) do
     ActiveRecord::Base.connection.begin_transaction(joinable: false)

--- a/spec/support/category.rb
+++ b/spec/support/category.rb
@@ -10,8 +10,8 @@ class Category < ActiveRecord::Base
   has_many :posts
 end
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :category do
-    name "Category"
+    name { "Category" }
   end
 end

--- a/spec/support/post.rb
+++ b/spec/support/post.rb
@@ -13,9 +13,9 @@ class Post < ActiveRecord::Base
   belongs_to :category
 end
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :post do
-    title "Title"
+    title { "Title" }
     user
     category
   end

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -10,8 +10,8 @@ class User < ActiveRecord::Base
   has_many :posts
 end
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
-    name "John"
+    name { "John" }
   end
 end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -14,7 +14,7 @@ Thread.abort_on_exception = true
 require "n_plus_one_control/minitest"
 require "benchmark"
 require "active_record"
-require "factory_girl"
+require "factory_bot"
 
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
 
@@ -33,4 +33,4 @@ module TransactionalTests
 end
 
 Minitest::Test.prepend TransactionalTests
-Minitest::Test.include FactoryGirl::Syntax::Methods
+Minitest::Test.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
## What is the purpose of this pull request?

Adds Ruby 3.1 and Rails 7 to the CI matrix

## What changes did you make? (overview)

1. Added a Rails 7 gemfile
2. Added Ruby 3.1 and Rails 7 entries to the CI configuration
3. Replaced use of factory_girl with factory_bot and make changes for recent versions of factory_bot
4. Remove Ruby 2.7 / Rails master configuration from CI, since that's not necessarily supported going forward

## Is there anything you'd like reviewers to focus on?

## Checklist

- [X] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation
