### PR TITLE
warmup logic fix

### DIFF
--- a/lib/n_plus_one_control/minitest.rb
+++ b/lib/n_plus_one_control/minitest.rb
@@ -59,7 +59,7 @@ module NPlusOneControl
     private
 
     def warming_up(warmup)
-      (warmup || methods.include?(:warmup) ? method(:warmup) : nil)&.call
+      (warmup || (methods.include?(:warmup) ? method(:warmup) : nil))&.call
     end
 
     def population_method

--- a/tests/minitest_test.rb
+++ b/tests/minitest_test.rb
@@ -46,6 +46,20 @@ class TestMinitestConstantQueries < Minitest::Test
       Post.find_each { |p| p.user.name }
     end
   end
+
+  def test_no_n_plus_one_error_with_warmup
+    populate = ->(n) { create_list(:post, n) }
+    warmed_up = false
+
+    assert_perform_constant_number_of_queries(
+      populate: populate,
+      warmup: -> { warmed_up = true }
+    ) do
+      true
+    end
+
+    assert warmed_up
+  end
 end
 
 class TestMinitestLinearQueries < Minitest::Test


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

Fixes issue that with minitest the `warmup` lambda can't be used, only a method.

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

## What changes did you make? (overview)

current logic is that if `warmup` was specified or a method exists, then
use the **method**. It should be use `warmup` lambda when specified or
method if is exists.

## Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation