### PR TITLE
Cached queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- add ability to ignore queries cached by the ORM with the new option `ignore_cached_queries` ([@gagalago][])
+
 ## 0.7.1 (2023-02-17)
 
 - Recognize private `#populate` and `#warmup` methods in Minitest classes. ([@palkan][])

--- a/README.md
+++ b/README.md
@@ -331,6 +331,10 @@ self.show_table_stats = true
 # Ignore matching queries
 NPlusOneControl.ignore = /^(BEGIN|COMMIT|SAVEPOINT|RELEASE)/
 
+# Ignore queries in cache 
+# https://guides.rubyonrails.org/configuring.html#configuring-query-cache
+NPlusOneControl.ignore_cached_queries = false
+
 # ActiveSupport notifications event to track queries.
 # We track ActiveRecord event by default,
 # but can also track rom-rb events ('sql.rom') as well.

--- a/lib/n_plus_one_control.rb
+++ b/lib/n_plus_one_control.rb
@@ -19,7 +19,7 @@ module NPlusOneControl
 
   class << self
     attr_accessor :default_scale_factors, :verbose, :show_table_stats, :ignore, :event,
-      :backtrace_cleaner, :backtrace_length, :truncate_query_size
+      :backtrace_cleaner, :backtrace_length, :truncate_query_size, :ignore_cached_queries
 
     attr_reader :default_matching
 
@@ -114,6 +114,9 @@ module NPlusOneControl
 
   # Ignore matching queries
   self.ignore = /^(BEGIN|COMMIT|SAVEPOINT|RELEASE)/
+
+  # Ignore queries cached
+  self.ignore_cached_queries = false
 
   # ActiveSupport notifications event to track queries.
   # We track ActiveRecord event by default,

--- a/lib/n_plus_one_control/executor.rb
+++ b/lib/n_plus_one_control/executor.rb
@@ -22,6 +22,7 @@ module NPlusOneControl
       def callback(_name, _start, _finish, _message_id, values) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/LineLength
         return if %w[CACHE SCHEMA].include? values[:name]
         return if values[:sql].match?(NPlusOneControl.ignore)
+        return if values[:cached] && NPlusOneControl.ignore_cached_queries
 
         return unless @pattern.nil? || (values[:sql] =~ @pattern)
 


### PR DESCRIPTION
## What is the purpose of this pull request?

sometimes Rails cache queries, so even if they are performed many times, in practice, they go only once to the database other stay in the Rails process. In that case, we can ignore to count them as they are close to free.

we can configure the cache of queries that way in rails: https://guides.rubyonrails.org/configuring.html#configuring-query-cache

## What changes did you make? (overview)

I added an option to ignore cached queries (false by default). 

corresponding code in rails that generate these events: [`ActiveRecord::QueryCache`](https://github.com/rails/rails/blob/4a45f3144c680f86655a24d21a9e014f694cca74/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb#L231-L284)

## Is there anything you'd like reviewers to focus on?

Naming of variables is always hard.

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
